### PR TITLE
Base64 encoding for some image packets and update node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "karma-spec-reporter": "0.0.26",
     "karma-webpack": "^2.0.1",
     "mocha": "^3.0.2",
-    "node-sass": "^4.5.0",
+    "node-sass": "^4.9.0",
     "require-dir": "^0.3.0",
     "sass-loader": "^6.0.3",
     "spectron": "^3.4.0",


### PR DESCRIPTION
- Base64 encoding for gif, jpeg, and png only; base64 encoding for other formats like svg are not implemented